### PR TITLE
SOLVED Bug: NAME was used as tableNAME and elementNAME while reading twiss

### DIFF
--- a/metaclass2.py
+++ b/metaclass2.py
@@ -43,6 +43,8 @@ class twiss2(dct):
 
       elif "@ " in line and "s" in splt[2]:
         label = splt[1].strip(":")
+        if label == "NAME": # recovering from bug: NAME has two uses
+          label = "TNAME"   # tableNAME and elementNAME!
         self[label] = splt[3].strip('"')
         self.types_parameters[label] = "%s"
 


### PR DESCRIPTION
SOLVED Bug: NAME was used as tableNAME and elementNAME while reading twiss

e.g.
$ python

> > > import metaclass2
> > > a = metaclass2.twiss2("twiss")
> > > a.elems[0].TNAME
> > > 'TWISS'
> > > a.elems[0].NAME
> > > \the_corresponding_element_name

before, TNAME did not exist and 'TWISS' was always returned as elementNAME.
